### PR TITLE
Make Makefile PREFIX overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 VERSION = 0.1
 
 # paths
-PREFIX = /usr
+PREFIX ?= /usr
 
 PROJDIRS := src
 SRCFILES := $(shell find $(PROJDIRS) -type f -name "*.cc")


### PR DESCRIPTION
User may not want or be able to install in /usr, and want to specify an
alternative.